### PR TITLE
Fix error that ignores the TextStyle if not it's inherited

### DIFF
--- a/lib/src/ellipsis_overflow_text.dart
+++ b/lib/src/ellipsis_overflow_text.dart
@@ -215,6 +215,8 @@ class EllipsisOverflowText extends StatelessWidget {
         TextStyle? textStyle;
         if (style == null || style!.inherit) {
           textStyle = defaultTextStyle.style.merge(style);
+        } else {
+          textStyle = style;
         }
         if (textStyle?.fontSize == null) {
           textStyle = textStyle?.copyWith(


### PR DESCRIPTION
The widget ignores the TextStyle provided if the ```.inherit``` property is no true. This is especially bad, as the TextStyles that come with the material theme seem not to use this property. Experienced the issue with:

 ```dart
EllipsisOverflowText(
  "Some text",
  style: Theme.of(context).textTheme.titleMedium,
)
```

The style provided will simply be ignored, falling back to the DefaultTextStyle.
This pull request fixes this.